### PR TITLE
Add compatibility with older versions

### DIFF
--- a/etc/skel/kytos/napp-structure/username/napp/kytos.json.template
+++ b/etc/skel/kytos/napp-structure/username/napp/kytos.json.template
@@ -1,4 +1,5 @@
 {
+  "author": "{{username}}",
   "username": "{{username}}",
   "name": "{{napp}}",
   "description": "{{description}}",

--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -135,7 +135,10 @@ class NAppsAPI:
         installed = mgr.get_installed()
         remote = set()
         for napp in remote_json:
-            remote.add(((napp['username'], napp['name']), napp['description']))
+            # WARNING: This will be changed in future versions, when 'author'
+            # will be removed.
+            username = napp.get('username', napp.get('author'))
+            remote.add(((username, napp.get('name')), napp.get('description')))
 
         napps = []
         for napp, desc in sorted(remote):

--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -129,10 +129,6 @@ class NAppsAPI:
         pat_str = '.*{}.*'.format(safe_shell_pat)
         pattern = re.compile(pat_str, re.IGNORECASE)
         remote_json = NAppsManager.search(pattern)
-
-        mgr = NAppsManager()
-        enabled = mgr.get_enabled()
-        installed = mgr.get_installed()
         remote = set()
         for napp in remote_json:
             # WARNING: This will be changed in future versions, when 'author'
@@ -140,8 +136,16 @@ class NAppsAPI:
             username = napp.get('username', napp.get('author'))
             remote.add(((username, napp.get('name')), napp.get('description')))
 
+        cls._print_napps(remote)
+
+    @classmethod
+    def _print_napps(cls, napp_list):
+        """Format the NApp list to be printed."""
+        mgr = NAppsManager()
+        enabled = mgr.get_enabled()
+        installed = mgr.get_installed()
         napps = []
-        for napp, desc in sorted(remote):
+        for napp, desc in sorted(napp_list):
             status = 'i' if napp in installed else '-'
             status += 'e' if napp in enabled else '-'
             status = '[{}]'.format(status)

--- a/kytos/utils/client.py
+++ b/kytos/utils/client.py
@@ -64,8 +64,12 @@ class NAppsClient():
             log.error("%s: %s", request.status_code, request.reason)
             sys.exit(1)
 
-        print("SUCCESS: NApp {}/{} uploaded.".format(metadata['username'],
-                                                     metadata['name']))
+        # WARNING: this will change in future versions, when 'author' will get
+        # removed.
+        username = metadata.get('username', metadata.get('author'))
+        name = metadata.get('name')
+
+        print("SUCCESS: NApp {}/{} uploaded.".format(username, name))
 
     @kytos_auth
     def delete(self, username, napp):

--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -173,8 +173,12 @@ class NAppsManager:
         """
         def match(napp):
             """Whether a NApp metadata matches the pattern."""
-            strings = ['{}/{}'.format(napp['username'], napp['name']),
-                       napp['description']] + napp['tags']
+            # WARNING: This will change for future versions, when 'author' will
+            # be removed.
+            username = napp.get('username', napp.get('author'))
+
+            strings = ['{}/{}'.format(username, napp.get('name')),
+                       napp.get('description')] + napp.get('tags')
             return any(pattern.match(string) for string in strings)
 
         napps = NAppsClient().get_napps()
@@ -212,8 +216,10 @@ class NAppsManager:
             if kytos_json.exists():
                 with kytos_json.open() as f:
                     meta = json.load(f)
-                    if meta['username'] == self.user and \
-                            meta['name'] == self.napp:
+                    # WARNING: This will change in future versions, when
+                    # 'author' will be removed.
+                    username = meta.get('username', meta.get('author'))
+                    if username == self.user and meta.get('name') == self.napp:
                         return kytos_json.parent
         raise FileNotFoundError('kytos.json not found.')
 
@@ -266,7 +272,7 @@ class NAppsManager:
         This will create, on the current folder, a clean structure of a NAPP,
         filling some contents on this structure.
         """
-        base = os.environ.get('VIRTUAL_ENV') or '/'
+        base = os.environ.get('VIRTUAL_ENV', '/')
 
         templates_path = os.path.join(base, 'etc', 'skel', 'kytos',
                                       'napp-structure', 'username', 'napp')
@@ -402,7 +408,7 @@ class NAppsManager:
             FileNotFoundError: If kytos.json is not found.
         """
         metadata = self.create_metadata(*args, **kwargs)
-        package = self.build_napp_package(metadata['name'])
+        package = self.build_napp_package(metadata.get('name'))
 
         NAppsClient().upload_napp(metadata, package)
 


### PR DESCRIPTION
Keep 'author' in some files for compatibility with older versions. We put warnings in the comments for lines that should be removed in future versions. This enables users of the latest version to install and run NApps created with 2017.1b1 version.