### PR TITLE
Fix 'NApps dir not found' error

### DIFF
--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -332,7 +332,7 @@ class NAppsManager:
             folder (pathlib.Path): Module path.
         """
         if not folder.exists():
-            folder.mkdir()
+            folder.mkdir(parents=True, exist_ok=True)
             (folder / '__init__.py').touch()
 
     @staticmethod

--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -332,7 +332,7 @@ class NAppsManager:
             folder (pathlib.Path): Module path.
         """
         if not folder.exists():
-            folder.mkdir(parents=True, exist_ok=True)
+            folder.mkdir(parents=True, exist_ok=True, mode=0o755)
             (folder / '__init__.py').touch()
 
     @staticmethod


### PR DESCRIPTION
Now kytos-utils creates the NApps directory structure if it doesn't exist

Signed-off-by: Macartur Sousa <macartur.sc@gmail.com>
Signed-off-by: Renan Rodrigo <renanrb@ime.usp.br>