### PR TITLE
creates napps directory with apropriate permissions

### DIFF
--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -232,6 +232,8 @@ class NAppsManager:
             napp_folder = self._get_local_folder(pkg_folder)
             dst = self._installed / self.user / self.napp
             self._check_module(dst.parent)
+            if not dst.exists():
+                dst.mkdir(mode=0o755)
             shutil.move(str(napp_folder), str(dst))
         finally:
             # Delete temporary files


### PR DESCRIPTION
shutil move() method creates the missing destination directory and its parents using os.makedirs() with default options (mode=0o777), but catches any exception which in my opinion could be caching an exception telling that the mode cannot be set. resulting in a destination directory with mode 700.
It is better to explicitly create the directory with the wanted permissions.
closes #77 .