### PR TITLE
Sets the correct permissions for the napp module folder.

### DIFF
--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -233,6 +233,7 @@ class NAppsManager:
             dst = self._installed / self.user / self.napp
             self._check_module(dst.parent)
             shutil.move(str(napp_folder), str(dst))
+            os.chmod(dst, mode=0o755)
         finally:
             # Delete temporary files
             if package:


### PR DESCRIPTION
shutils move() method renames the src directory with the destination name, and then makes a copy. But the src dir was created with mkdtemp() method, which creates it with mode 0x700.
It is better to explicitly set the directory with the wanted permissions.
closes #77 .