### PR TITLE
fixes napps username/napp_name parsing

### DIFF
--- a/kytos/cli/commands/napps/parser.py
+++ b/kytos/cli/commands/napps/parser.py
@@ -72,7 +72,7 @@ def parse_napps(napp_args):
     def parse_napp(arg):
         """Parse one argument."""
         napp = arg.split('/')
-        size_is_valid = len(napp) == 2 and len(napp[0]) and len(napp[1])
+        size_is_valid = len(napp) == 2 and napp[0] and napp[1]
         if not size_is_valid:
             msg = '"{}" NApp has not the form username/napp_name.'.format(arg)
             raise KytosException(msg)

--- a/kytos/cli/commands/napps/parser.py
+++ b/kytos/cli/commands/napps/parser.py
@@ -72,8 +72,8 @@ def parse_napps(napp_args):
     def parse_napp(arg):
         """Parse one argument."""
         napp = arg.split('/')
-        size_is_valid = len(napp) != 2 or len(napp[0]) or len(napp[1])
-        if size_is_valid:
+        size_is_valid = len(napp) == 2 and len(napp[0]) and len(napp[1])
+        if not size_is_valid:
             msg = '"{}" NApp has not the form username/napp_name.'.format(arg)
             raise KytosException(msg)
         return tuple(napp)


### PR DESCRIPTION
$ kytos napps install kytos/of_l2ls
Error parsing args: "kytos/of_l2ls" NApp has not the form username/napp_name.