### PR TITLE
Increase project version to a dev state.

### DIFF
--- a/bin/kytos
+++ b/bin/kytos
@@ -30,7 +30,7 @@ logging.basicConfig(format='%(levelname)-5s %(message)s', level=logging.INFO)
 
 if __name__ == '__main__':
     args = docopt(__doc__,
-                  version='kytos command line, version 2017.1b3',
+                  version='kytos command line, version 2017.1rc1.dev0',
                   options_first=True)
     command = args['<command>']
     command_args = args['<args>']

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ class DevelopMode(develop):
 REQS = [i.strip() for i in open("requirements.txt").readlines()]
 
 setup(name='kytos-utils',
-      version='2017.1b3',
+      version='2017.1rc1.dev0',
       description='Command line utilities to use with Kytos.',
       url='http://github.com/kytos/kytos-utils',
       author='Kytos Team',


### PR DESCRIPTION
Changing the project version to be ahead of the last (pre-)release [2017.1b3].
In this way, when installed from the current source code we can be sure that
the code is newer than the released code/package.