### PR TITLE
[minor] Downgrade pylama

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,10 @@
-coverage >= 4.1
-pydocstyle ~= 1.1
-pylama ~= 7.3
-pylama_pylint ~= 3.0
-radon ~= 1.5
+# Linters, also in test target
+# Pylama still not compatible with pydocstyle version 2.
+# Bug report in https://github.com/klen/pylama/issues/96
+pydocstyle ~= 1.1.1
+pylama ~= 7.3.3
+pylama_pylint ~= 3.0.1
+radon ~= 1.5.0
+tox ~= 2.7.0
+
+coverage >= 4.4.1


### PR DESCRIPTION
After last Pylama release, we have new linter warnings to be fixed in
a later version.