### PR TITLE
Remove circular dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,6 @@ setup(name='kytos-utils',
           'requests',
           'jinja2>=2.9.5',
           'ruamel.yaml',
-          'kytos>=2017.2b2.dev0'
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
Kytos cannot be installed with the current kytos-utils. This patch fix
this problem.

This is due to our highly-costumized setup.py in kytos project. Before
anything, even before installing requirements/dev.txt when specified,
kytos installs requirements/run.in. The problem is that kytos-utils is
in run.in file and kytos-utils is depending on the latest version found
in kytos repo (not yet in Pypi). Thus, kytos installation is failing for
devs. This patch removes kytos project from install dependencies and
still keeps it in dev dependencies.