### PR TITLE
Enhanced error messages when uninstalling/disabling NApps

### DIFF
--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -41,7 +41,9 @@ class NAppsAPI:
         if mgr.is_enabled():
             LOG.info('  Disabling...')
             mgr.disable()
-        LOG.info('  Disabled.')
+            LOG.info('  Disabled.')
+        else:
+            LOG.error("  NApp isn't enabled.")
 
     @classmethod
     def enable(cls, args):
@@ -111,7 +113,9 @@ class NAppsAPI:
                     cls.disable_napp(mgr)
                 LOG.info('  Uninstalling...')
                 mgr.uninstall()
-            LOG.info('  Uninstalled.')
+                LOG.info('  Uninstalled.')
+            else:
+                LOG.error("  NApp isn't installed.")
 
     @classmethod
     def install(cls, args):


### PR DESCRIPTION
I accidentally typed the wrong name when I was disabling/uninstalling a NApp and I noticed the logs messages weren't coherent:

```
~/repos/kytos master*
❯ kytos napps disable kytos/inexistent
INFO  NApp kytos/inexistent:
INFO    Disabled.

~/repos/kytos master*
❯ kytos napps uninstall kytos/inexistent
INFO  NApp kytos/inexistent:
INFO    Uninstalled.

```

With this PR you get this instead:


```
~/repos/kytos master*
❯ kytos napps uninstall kytos/inexistent
INFO  NApp kytos/inexistent:
ERROR   NApp isn't installed.

~/repos/kytos master*
❯ kytos napps disable kytos/inexistent
INFO  NApp kytos/inexistent:
ERROR   NApp isn't enabled.

```
