### PR TITLE
Napp version inicialize in version 1.0 (#215)

### DIFF
--- a/etc/kytos/skel/napp-structure/username/napp/kytos.json.template
+++ b/etc/kytos/skel/napp-structure/username/napp/kytos.json.template
@@ -3,7 +3,7 @@
   "username": "{{username}}",
   "name": "{{napp}}",
   "description": "{{description}}",
-  "version": "latest",
+  "version": "1.0",
   "napp_dependencies": [],
   "license": "",
   "tags": [],


### PR DESCRIPTION
Now, napps inicialize with "1.0" version, no more "latest".