### PR TITLE
Fix wrong error message on command enable NApp

### DIFF
--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -65,7 +65,12 @@ class NAppsAPI:
             if not mgr.is_enabled():
                 LOG.info('    Enabling...')
                 mgr.enable()
-            LOG.info('    Enabled.')
+
+            # Check if NApp is enabled
+            if mgr.is_enabled():
+                LOG.info('    Enabled.')
+            else:
+                LOG.error('    Error enabling NApp.')
         except (FileNotFoundError, PermissionError) as exception:
             LOG.error('  %s', exception)
 

--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -140,6 +140,8 @@ class NAppsAPI:
                     # Try to install all NApps, even if
                     # some of them fail.
                     cls.install_napp(mgr)
+
+                    # Enable the NApp
                     if not mgr.is_enabled():
                         cls.enable_napp(mgr)
                         napp_dependencies = mgr.dependencies()
@@ -147,7 +149,7 @@ class NAppsAPI:
                             LOG.info('Installing Dependencies:')
                             cls.install_napps(napp_dependencies)
                     else:
-                        LOG.warning('  Napp already enabled.')
+                        LOG.info('    Enabled.')
                 else:
                     LOG.warning('  Napp already installed.')
             except KytosException:


### PR DESCRIPTION
Fix issue #227.
Modified the command **`kytos napps enable`** to properly display an error if the user is enabling a NApp that is not installed.

The output now is:
```
$ kytos napps enable foo/bar
INFO  NApp foo/bar:
INFO      Enabling...
ERROR NApp is not installed. Check the NApp list.
ERROR     Error enabling NApp.
```
