### PR TITLE
Remove kytos dependency from requirements/dev.in

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,2 +1,1 @@
 -e .[dev]
--e git+git://github.com/kytos/kytos.git#egg=kytos


### PR DESCRIPTION
Remove the link /github.com/kytos/kytos dependency from the file requirements/dev.in
