### PR TITLE
Update kytos-utils to run some commands without kytos running (Fix #262)

### DIFF
--- a/kytos/utils/config.py
+++ b/kytos/utils/config.py
@@ -10,9 +10,10 @@ import json
 import logging
 import os
 import re
-import urllib.request
 from collections import namedtuple
 from configparser import ConfigParser
+from urllib.error import URLError
+from urllib.request import urlopen
 
 LOG = logging.getLogger(__name__)
 
@@ -140,19 +141,23 @@ class KytosConfig():
         """Return kytos metadata."""
         kytos_api = KytosConfig().config.get('kytos', 'api')
         meta_uri = kytos_api + 'api/kytos/core/metadata/'
-        meta_file = urllib.request.urlopen(meta_uri).read()
+        meta_file = urlopen(meta_uri).read()
         metadata = json.loads(meta_file)
         return metadata
 
     @classmethod
     def check_versions(cls):
         """Check if kytos and kytos-utils metadata are compatible."""
-        kytos_metadata = cls.get_remote_metadata()
-        kutils_metadata = cls.get_metadata()
-        kytos_version = kytos_metadata.get('__version__')
-        kutils_version = kutils_metadata.get('__version__')
+        try:
+            kytos_metadata = cls.get_remote_metadata()
+            kytos_version = kytos_metadata.get('__version__')
+        except URLError as exc:
+            LOG.debug('Couldn\'t connect to kytos server: %s', exc)
+        else:
+            kutils_metadata = cls.get_metadata()
+            kutils_version = kutils_metadata.get('__version__')
 
-        if kytos_version != kutils_version:
-            logger = logging.getLogger()
-            logger.warning('kytos (%s) and kytos utils (%s) versions '
-                           'are not equal.', kytos_version, kutils_version)
+            if kytos_version != kutils_version:
+                logger = logging.getLogger()
+                logger.warning('kytos (%s) and kytos utils (%s) versions '
+                               'are not equal.', kytos_version, kutils_version)


### PR DESCRIPTION
Today, kytos-utils won't run any command if kytosd isn't running. This commit solves this problem, now some commands can be executed even if kytos isn't running.