### PR TITLE
Merge pull request #265 from cmagnobarbosa/long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ METADATA = dict(re.findall(r"(__[a-z]+__)\s*=\s*'([^']+)'", META_FILE))
 setup(name='kytos-utils',
       version=METADATA.get('__version__'),
       description=METADATA.get('__description__'),
+      long_description=open("README.rst", "r").read(),
       url=METADATA.get('__url__'),
       author=METADATA.get('__author__'),
       author_email=METADATA.get('__author_email__'),


### PR DESCRIPTION
Today, the package hosted in PyPI does not have a long description,
this commit adds the long_description field by reading the README.rst file.