### PR TITLE
Fix Scrutinizer Coverage Error

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ filter:
         - 'bin/*'
 build:
     environment:
-        python: 3.6.0
+        python: 3.6.3
         postgresql: false
         redis: false
     dependencies:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 astroid==2.0.4            # via pylint
 click==7.0                # via pip-tools
-coverage==4.5.1
+coverage==5.0.3
 docopt==0.6.2             # via yala
 importlib-metadata==1.3.0  # via pluggy
 isort==4.3.4              # via pylint, yala


### PR DESCRIPTION
The coverage version was creating an error when running Scrutinizer. This commit changes coverage version from 4.5.1 to 5.0.3 and update python version from 3.6.0 to 3.6.3.