### PR TITLE
Fix error message when trying to install local NApps

### DIFF
--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -177,9 +177,9 @@ class NAppsAPI:
         except HTTPError as exception:
             if exception.code == 404:
                 LOG.error('    NApp not found.')
-                LOG.info("    If you are trying to install a local NApp, you h"
-                         "ave to use the command 'python setup.py install' ins"
-                         "ide of the 'user/napp' directory.")
+                LOG.info("    If you are trying to install a local NApp, "
+                         "use the command 'python setup.py develop' "
+                         "inside the 'user/napp' directory.")
             elif exception.code == 400:
                 LOG.error('    NApps Server error: %s', exception)
         except URLError as exception:

--- a/kytos/cli/commands/napps/api.py
+++ b/kytos/cli/commands/napps/api.py
@@ -177,7 +177,10 @@ class NAppsAPI:
         except HTTPError as exception:
             if exception.code == 404:
                 LOG.error('    NApp not found.')
-            else:
+                LOG.info("    If you are trying to install a local NApp, you h"
+                         "ave to use the command 'python setup.py install' ins"
+                         "ide of the 'user/napp' directory.")
+            elif exception.code == 400:
                 LOG.error('    NApps Server error: %s', exception)
         except URLError as exception:
             LOG.error('    NApps Server error: %s', str(exception.reason))

--- a/kytos/templates/skel/napp-structure/username/napp/setup.py.template
+++ b/kytos/templates/skel/napp-structure/username/napp/setup.py.template
@@ -12,20 +12,16 @@ from subprocess import call, check_call
 
 from setuptools import Command, setup
 from setuptools.command.develop import develop
-from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
 if 'bdist_wheel' in sys.argv:
     raise RuntimeError("This setup.py does not support wheels")
 
 # Paths setup with virtualenv detection
-if 'VIRTUAL_ENV' in os.environ:
-    BASE_ENV = Path(os.environ['VIRTUAL_ENV'])
-else:
-    BASE_ENV = Path('/')
+BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = '{{napp}}'
-NAPP_VERSION = '0.0'
+NAPP_VERSION = '0.1'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'
@@ -99,7 +95,7 @@ class CITest(SimpleCommand):
 
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
-        cmds = ['python3.6 setup.py ' + cmd
+        cmds = ['python3 setup.py ' + cmd
                 for cmd in ('coverage', 'lint')]
         cmd = ' && '.join(cmds)
         check_call(cmd, shell=True)
@@ -117,22 +113,6 @@ class KytosInstall:
             src = ENABLED_PATH / napp_path
             dst = INSTALLED_PATH / napp_path
             symlink_if_different(src, dst)
-
-
-class EggInfo(egg_info):
-    """Prepare files to be packed."""
-
-    def run(self):
-        """Build css."""
-        # self._install_deps_wheels()
-        super().run()
-
-    # @staticmethod
-    # def _install_deps_wheels():
-    #    """Python wheels are much faster (no compiling)."""
-    #    print('Installing dependencies...')
-    #    check_call([sys.executable, '-m', 'pip', 'install', '-r',
-    #                'requirements/run.in'])
 
 
 class InstallMode(install):
@@ -245,12 +225,11 @@ setup(name=f'kytos_{NAPP_NAME}',
           'develop': DevelopMode,
           'install': InstallMode,
           'lint': Linter,
-          'egg_info': EggInfo,
       },
       zip_safe=False,
       classifiers=[
           'License :: OSI Approved :: MIT License',
           'Operating System :: POSIX :: Linux',
-          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3',
           'Topic :: System :: Networking',
       ])

--- a/kytos/templates/skel/napp-structure/username/napp/setup.py.template
+++ b/kytos/templates/skel/napp-structure/username/napp/setup.py.template
@@ -1,0 +1,256 @@
+"""Setup script.
+
+Run "python3 setup.py --help-commands" to list all available commands and their
+descriptions.
+"""
+import os
+import shutil
+import sys
+from abc import abstractmethod
+from pathlib import Path
+from subprocess import call, check_call
+
+from setuptools import Command, setup
+from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
+from setuptools.command.install import install
+
+if 'bdist_wheel' in sys.argv:
+    raise RuntimeError("This setup.py does not support wheels")
+
+# Paths setup with virtualenv detection
+if 'VIRTUAL_ENV' in os.environ:
+    BASE_ENV = Path(os.environ['VIRTUAL_ENV'])
+else:
+    BASE_ENV = Path('/')
+
+NAPP_NAME = '{{napp}}'
+NAPP_VERSION = '0.0'
+
+# Kytos var folder
+VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'
+# Path for enabled NApps
+ENABLED_PATH = VAR_PATH / 'napps'
+# Path to install NApps
+INSTALLED_PATH = VAR_PATH / 'napps' / '.installed'
+CURRENT_DIR = Path('.').resolve()
+
+# NApps enabled by default
+CORE_NAPPS = []
+
+
+class SimpleCommand(Command):
+    """Make Command implementation simpler."""
+
+    user_options = []
+
+    @abstractmethod
+    def run(self):
+        """Run when command is invoked.
+
+        Use *call* instead of *check_call* to ignore failures.
+        """
+
+    def initialize_options(self):
+        """Set default values for options."""
+
+    def finalize_options(self):
+        """Post-process options."""
+
+
+class Cleaner(SimpleCommand):
+    """Custom clean command to tidy up the project root."""
+
+    description = 'clean build, dist, pyc and egg from package and docs'
+
+    def run(self):
+        """Clean build, dist, pyc and egg from package and docs."""
+        call('rm -vrf ./build ./dist ./*.egg-info', shell=True)
+        call('find . -name __pycache__ -type d | xargs rm -rf', shell=True)
+        call('make -C docs/ clean', shell=True)
+
+
+class TestCoverage(SimpleCommand):
+    """Display test coverage."""
+
+    description = 'run unit tests and display code coverage'
+
+    def run(self):
+        """Run unittest quietly and display coverage report."""
+        cmd = 'coverage3 run -m unittest && coverage3 report'
+        call(cmd, shell=True)
+
+
+class Linter(SimpleCommand):
+    """Code linters."""
+
+    description = 'lint Python source code'
+
+    def run(self):
+        """Run yala."""
+        print('Yala is running. It may take several seconds...')
+        check_call('yala *.py', shell=True)
+
+
+class CITest(SimpleCommand):
+    """Run all CI tests."""
+
+    description = 'run all CI tests: unit and doc tests, linter'
+
+    def run(self):
+        """Run unit tests with coverage, doc tests and linter."""
+        cmds = ['python3.6 setup.py ' + cmd
+                for cmd in ('coverage', 'lint')]
+        cmd = ' && '.join(cmds)
+        check_call(cmd, shell=True)
+
+
+class KytosInstall:
+    """Common code for all install types."""
+
+    @staticmethod
+    def enable_core_napps():
+        """Enable a NAPP by creating a symlink."""
+        (ENABLED_PATH / '{{username}}').mkdir(parents=True, exist_ok=True)
+        for napp in CORE_NAPPS:
+            napp_path = Path('{{username}}', napp)
+            src = ENABLED_PATH / napp_path
+            dst = INSTALLED_PATH / napp_path
+            symlink_if_different(src, dst)
+
+
+class EggInfo(egg_info):
+    """Prepare files to be packed."""
+
+    def run(self):
+        """Build css."""
+        # self._install_deps_wheels()
+        super().run()
+
+    # @staticmethod
+    # def _install_deps_wheels():
+    #    """Python wheels are much faster (no compiling)."""
+    #    print('Installing dependencies...')
+    #    check_call([sys.executable, '-m', 'pip', 'install', '-r',
+    #                'requirements/run.in'])
+
+
+class InstallMode(install):
+    """Class used to overwrite the default installation using setuptools."""
+
+
+    def run(self):
+        """Install the package in install mode.
+
+        super().run() does not install dependencies when running
+        ``python setup.py install`` (pypa/setuptools#456).
+        """
+        print(f'Installing NApp {{username}}/{{napp}}...')
+        install_path = Path(INSTALLED_PATH)
+
+        if not install_path.exists():
+            # Create '.installed' dir if installing the first NApp in Kytos
+            install_path.mkdir(parents=True, exist_ok=True)
+        elif (install_path / '{{username}}').exists():
+            # It cleans an old installation
+            shutil.rmtree(install_path / '{{username}}')
+
+        # The path where the NApp will be installed
+        napp_path = install_path / '{{username}}' / NAPP_NAME
+
+        src = CURRENT_DIR
+        shutil.copytree(src, napp_path)
+        (napp_path.parent / '__init__.py').touch()
+        KytosInstall.enable_core_napps()
+        print('NApp installed.')
+
+
+class DevelopMode(develop):
+    """Recommended setup for kytos-napps developers.
+
+    Instead of copying the files to the expected directories, a symlink is
+    created on the system aiming the current source code.
+    """
+
+    description = 'Install NApps in development mode'
+
+    def run(self):
+        """Install the package in a developer mode."""
+        super().run()
+        if self.uninstall:
+            shutil.rmtree(str(ENABLED_PATH), ignore_errors=True)
+        else:
+            self._create_folder_symlinks()
+            # self._create_file_symlinks()
+            KytosInstall.enable_core_napps()
+
+    @staticmethod
+    def _create_folder_symlinks():
+        """Symlink to all Kytos NApps folders.
+
+        ./napps/kytos/napp_name will generate a link in
+        var/lib/kytos/napps/.installed/kytos/napp_name.
+        """
+        links = INSTALLED_PATH / '{{username}}'
+        links.mkdir(parents=True, exist_ok=True)
+        code = CURRENT_DIR
+        src = links / NAPP_NAME
+        symlink_if_different(src, code)
+
+        (ENABLED_PATH / '{{username}}').mkdir(parents=True, exist_ok=True)
+        dst = ENABLED_PATH / Path('{{username}}', NAPP_NAME)
+        symlink_if_different(dst, src)
+
+    @staticmethod
+    def _create_file_symlinks():
+        """Symlink to required files."""
+        src = ENABLED_PATH / '__init__.py'
+        dst = CURRENT_DIR / '{{username}}' / '__init__.py'
+        symlink_if_different(src, dst)
+
+
+def symlink_if_different(path, target):
+    """Force symlink creation if it points anywhere else."""
+    # print(f"symlinking {path} to target: {target}...", end=" ")
+    if not path.exists():
+        # print(f"path doesn't exist. linking...")
+        path.symlink_to(target)
+    elif not path.samefile(target):
+        # print(f"path exists, but is different. removing and linking...")
+        # Exists but points to a different file, so let's replace it
+        path.unlink()
+        path.symlink_to(target)
+
+
+setup(name=f'kytos_{NAPP_NAME}',
+      version=NAPP_VERSION,
+      description='Core NApps developed by the Kytos Team',
+      url=f'http://github.com/kytos/{NAPP_NAME}',
+      author='Kytos Team',
+      author_email='of-ng-dev@ncc.unesp.br',
+      license='MIT',
+      install_requires=['setuptools >= 36.0.1'],
+      extras_require={
+          'dev': [
+              'coverage',
+              'pip-tools',
+              'yala',
+              'tox',
+          ],
+      },
+      cmdclass={
+          'clean': Cleaner,
+          'ci': CITest,
+          'coverage': TestCoverage,
+          'develop': DevelopMode,
+          'install': InstallMode,
+          'lint': Linter,
+          'egg_info': EggInfo,
+      },
+      zip_safe=False,
+      classifiers=[
+          'License :: OSI Approved :: MIT License',
+          'Operating System :: POSIX :: Linux',
+          'Programming Language :: Python :: 3.6',
+          'Topic :: System :: Networking',
+      ])

--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -304,7 +304,6 @@ class NAppsManager:
 
         json.loads(urllib.request.urlopen(uri).read())
 
-
     @classmethod
     def create_napp(cls, meta_package=False):
         """Bootstrap a basic NApp structure for you to develop your NApp.

--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -302,13 +302,8 @@ class NAppsManager:
         uri = self._kytos_api + self._NAPP_INSTALL
         uri = uri.format(self.user, self.napp)
 
-        try:
-            json.loads(urllib.request.urlopen(uri).read())
-        except urllib.error.HTTPError as exception:
-            if exception.code == HTTPStatus.BAD_REQUEST.value:
-                LOG.error("NApp is not installed. Check the NApp list.")
-            else:
-                LOG.error("Error installing the NApp.")
+        json.loads(urllib.request.urlopen(uri).read())
+
 
     @classmethod
     def create_napp(cls, meta_package=False):

--- a/tests/unit/commands/test_napps_api.py
+++ b/tests/unit/commands/test_napps_api.py
@@ -1,10 +1,12 @@
 """kytos.cli.commands.napps.api.NAppsAPI tests."""
 import unittest
 from unittest.mock import MagicMock, call, patch
+from urllib.error import HTTPError
 
 import requests
 
 from kytos.cli.commands.napps.api import NAppsAPI
+from kytos.utils.exceptions import KytosException
 
 
 # pylint: disable=too-many-public-methods
@@ -179,6 +181,35 @@ class TestNAppsAPI(unittest.TestCase):
         self.napps_api.install_napp(mgr)
 
         mgr.remote_install.assert_called()
+
+    @patch('kytos.utils.napps.NAppsManager')
+    def test_install_napp_error_404(self, mgr):
+        """Test install_napp method."""
+        mgr = MagicMock()
+
+        url = 'www.napps.kytos.io'
+        msg = 'The NApp were not found at server.'
+        code = 404
+        hdrs = 'The HTTP response headers'
+        filep = None
+        mgr.remote_install.side_effect = HTTPError(url, code, msg, hdrs, filep)
+        with self.assertRaises(KytosException):
+            self.napps_api.install_napp(mgr)
+
+    @patch('kytos.utils.napps.NAppsManager')
+    def test_install_napp_error_400(self, mgr):
+        """Test install_napp method."""
+        mgr = MagicMock()
+
+        url = 'www.napps.kytos.io'
+        msg = 'The NApp were not found at server.'
+        code = 400
+        hdrs = 'The HTTP response headers'
+        filep = None
+        mgr.remote_install.side_effect = HTTPError(url, code, msg, hdrs, filep)
+
+        with self.assertRaises(KytosException):
+            self.napps_api.install_napp(mgr)
 
     @patch('kytos.cli.commands.napps.api.NAppsManager.search')
     @patch('kytos.cli.commands.napps.api.NAppsAPI._print_napps')

--- a/tests/unit/commands/test_napps_api.py
+++ b/tests/unit/commands/test_napps_api.py
@@ -187,7 +187,7 @@ class TestNAppsAPI(unittest.TestCase):
         """Test install_napp method."""
         mgr = MagicMock()
 
-        url = 'www.napps.kytos.io'
+        url = 'napps.kytos.io'
         msg = 'The NApp were not found at server.'
         code = 404
         hdrs = 'The HTTP response headers'
@@ -201,7 +201,7 @@ class TestNAppsAPI(unittest.TestCase):
         """Test install_napp method."""
         mgr = MagicMock()
 
-        url = 'www.napps.kytos.io'
+        url = 'napps.kytos.io'
         msg = 'The NApp were not found at server.'
         code = 400
         hdrs = 'The HTTP response headers'

--- a/tests/unit/test_napps.py
+++ b/tests/unit/test_napps.py
@@ -445,20 +445,6 @@ class TestNapps(unittest.TestCase):
 
         mock_urlopen.assert_called_with(uri)
 
-    @patch('kytos.utils.napps.LOG')
-    @patch('urllib.request.urlopen')
-    def test_remote_install__error(self, *args):
-        """Test remote_install method to error case."""
-        (mock_urlopen, mock_logger) = args
-        http_errors = [HTTPError('url', 400, 'msg', 'hdrs', MagicMock()),
-                       HTTPError('url', 500, 'msg', 'hdrs', MagicMock())]
-        mock_urlopen.side_effect = http_errors
-
-        self.napps_manager.remote_install()
-        self.napps_manager.remote_install()
-
-        self.assertEqual(mock_logger.error.call_count, 2)
-
     def test_valid_name(self):
         """Test valid_name method."""
         valid_name = self.napps_manager.valid_name('username')


### PR DESCRIPTION
The issue #278 describe a problem installing a local NApp using the kytos tutorial.
After create a NApp using 'kytos napps create'  the attempt to install the created NApp it was returing the following result:

> INFO    NApp test/helloworld:
INFO      Downloading from NApps Server...
ERROR Error installing the NApp.
INFO      Downloaded and installed.
INFO      Enabling...
ERROR NApp is not installed. Check the NApp list.
ERROR     Error enabling NApp.
...
 urllib.error.HTTPError: HTTP Error 400: BAD REQUEST

You can check the issue #278 for the complete output above. To solve this problem it is necessary improve the following:

- Let the module kytos/cli/commands/napps/api.py handle with HTTP code 400. (9a53047)
- Inform the user to install the created NApp using 'setup.py'. (9a53047)  
- Create a template for setup.py to be added when a new NApp is created. (76caa18, a16e539)