### PR TITLE
Create tags decorator to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-source = .
+source = kytos
 omit = .eggs/*,.tox/*,*tests*,.bin/*,setup.py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,6 +24,7 @@ py==1.8.1                 # via tox
 pycodestyle==2.5.0        # via yala
 pylint==2.4.4             # via yala
 pyparsing==2.4.6          # via packaging
+pytest==5.4.1             # via pytest
 six==1.14.0               # via astroid, packaging, pip-tools, tox, virtualenv
 toml==0.10.0              # via tox
 tox==3.14.6               # via -r requirements/dev.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,9 @@ add-ignore = D105
 [isort]
 # The first party was necessary.
 known_first_party = kytos.utils,kytos.cli
+
+[tool:pytest]
+markers =
+    small: marks tests as small
+    medium: marks tests as medium
+    large: marks tests as large

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,39 @@ class SimpleCommand(Command):
         """Post-process options."""
 
 
+# pylint: disable=attribute-defined-outside-init, abstract-method
+class TestCommand(Command):
+    """Test tags decorators."""
+
+    user_options = [
+        ('size=', None, 'Specify the size of tests to be executed.'),
+        ('type=', None, 'Specify the type of tests to be executed.'),
+    ]
+
+    sizes = ('small', 'medium', 'large', 'all')
+    types = ('unit', 'integration', 'e2e')
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        return '--size %s --type %s' % (self.size, self.type)
+
+    def initialize_options(self):
+        """Set default size and type args."""
+        self.size = 'all'
+        self.type = 'unit'
+
+    def finalize_options(self):
+        """Post-process."""
+        try:
+            assert self.size in self.sizes, ('ERROR: Invalid size:'
+                                             f':{self.size}')
+            assert self.type in self.types, ('ERROR: Invalid type:'
+                                             f':{self.type}')
+        except AssertionError as exc:
+            print(exc)
+            sys.exit(-1)
+
+
 class Cleaner(clean):
     """Custom clean command to tidy up the project root."""
 
@@ -51,26 +84,54 @@ class Cleaner(clean):
         call('test -d docs && make -C docs/ clean', shell=True)
 
 
-class TestCoverage(SimpleCommand):
-    """Display test coverage."""
+class Test(TestCommand):
+    """Run all tests."""
 
-    description = 'run unit tests and display code coverage'
+    description = 'run tests and display results'
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        markers = self.size
+        if markers == "small":
+            markers = 'not medium and not large'
+        size_args = "" if self.size == "all" else "-m '%s'" % markers
+        return '--addopts="tests/%s %s"' % (self.type, size_args)
 
     def run(self):
-        """Run unittest quietly and display coverage report."""
-        cmd = 'coverage3 run --source=kytos setup.py test && coverage3 report'
-        check_call(cmd, shell=True)
+        """Run tests."""
+        cmd = 'python setup.py pytest %s' % self.get_args()
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
 
 
-class CITest(SimpleCommand):
+class TestCoverage(Test):
+    """Display test coverage."""
+
+    description = 'run tests and display code coverage'
+
+    def run(self):
+        """Run tests quietly and display coverage report."""
+        cmd = 'coverage3 run setup.py pytest %s' % self.get_args()
+        cmd += '&& coverage3 report'
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
+
+
+class CITest(TestCommand):
     """Run all CI tests."""
 
     description = 'run all CI tests: unit and doc tests, linter'
 
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
-        for command in TestCoverage, Linter:
-            command(*self._args, **self._kwargs).run()
+        coverage_cmd = 'python3.6 setup.py coverage %s' % self.get_args()
+        lint_cmd = 'python3.6 setup.py lint'
+        cmd = '%s && %s' % (coverage_cmd, lint_cmd)
+        check_call(cmd, shell=True)
 
 
 class Linter(SimpleCommand):
@@ -109,11 +170,14 @@ setup(name='kytos-utils',
       install_requires=[line.strip()
                         for line in open("requirements/run.txt").readlines()
                         if not line.startswith('#')],
+      setup_requires=['pytest-runner'],
+      tests_require=['pytest'],
       packages=find_packages(exclude=['tests']),
       cmdclass={
           'ci': CITest,
           'clean': Cleaner,
           'coverage': TestCoverage,
-          'lint': Linter
+          'lint': Linter,
+          'test': Test
       },
       zip_safe=False)

--- a/tests/unit/commands/test_napps_api.py
+++ b/tests/unit/commands/test_napps_api.py
@@ -193,12 +193,17 @@ class TestNAppsAPI(unittest.TestCase):
 
         mock_print.assert_called_with({(('kytos', 'mef_eline'), '')})
 
+    @patch('os.popen')
     @patch('builtins.print')
     @patch('kytos.cli.commands.napps.api.NAppsManager')
     def test_print_napps(self, *args):
         """Test _print_napps method."""
-        (mock_napps_manager, mock_print) = args
+        (mock_napps_manager, mock_print, mock_popen) = args
         napps = [('kytos', 'mef_eline')]
+
+        mock_test = MagicMock()
+        mock_test.read.return_value = '1000 1000'
+        mock_popen.return_value = mock_test
 
         mgr = MagicMock()
         mgr.get_enabled.return_value = napps


### PR DESCRIPTION
Today, all the tests are executed without distinction. This commit creates a tag to divide tests in type (unit, integration, e2e) and in size (small, medium, large).