### PR TITLE
Fix error message when checking for enabled NApps

### DIFF
--- a/kytos/utils/napps.py
+++ b/kytos/utils/napps.py
@@ -129,7 +129,7 @@ class NAppsManager:
             content = json.loads(response.read())
             return sorted((c[0], c[1]) for c in content['napps'])
         except urllib.error.URLError as exception:
-            LOG.error("Error checking installed NApps. Is Kytos running?")
+            LOG.error("Error checking enabled NApps. Is Kytos running?")
             raise KytosException(exception)
 
     def get_installed(self):


### PR DESCRIPTION
The get_enabled() function throws an Error with the message this "Error checking **installed** NApps". This PR change it to
to "checking **enabled** Napps".