### PR TITLE
Fix Scrutinizer run not finding lzma module

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,11 +8,12 @@ filter:
         - 'bin/*'
 build:
     environment:
-        python: 3.6.3
+        python: 3.6.9
         postgresql: false
         redis: false
     dependencies:
         before:
+            - pip install tox
             - pip install coverage
     tests:
         override:


### PR DESCRIPTION
Scrutinizer run is not finding the lzma module to run unit tests.
The problem is that this module is not compiled in the specified Python version.
This fix upgrade the Python version to run in Scrutinizer to 3.6.9 and update the script to install tox for this version.