### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,11 @@ descriptions.
 import re
 import sys
 from abc import abstractmethod
-# Disabling checks due to https://github.com/PyCQA/pylint/issues/73
-from distutils.command.clean import clean  # pylint: disable=E0401,E0611
 from subprocess import CalledProcessError, call, check_call
 
 from setuptools import Command, find_packages, setup
-
+# Disabling checks due to https://github.com/PyCQA/pylint/issues/73
+from distutils.command.clean import clean  # pylint: disable=E0401,E0611
 
 class SimpleCommand(Command):
     """Make Command implementation simpler."""


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022466

### :computer: Verification Process

Run `setup.py` with a current setuptools. If it blows up, there's a problem.

### :page_facing_up: Release Notes

* Add support for setuptools >= 60.